### PR TITLE
infra: updated dependency for mtdb.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,12 @@ module mapcleaner
 
 go 1.17
 
-require github.com/minetest-go/mapparser v0.1.8
+require (
+	github.com/minetest-go/areasparser v1.0.0
+	github.com/minetest-go/mapparser v0.1.8
+	github.com/minetest-go/mtdb v1.1.33
+	github.com/sirupsen/logrus v1.9.0
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -15,14 +20,11 @@ require (
 	github.com/lib/pq v1.10.7 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
-	github.com/minetest-go/areasparser v1.0.0 // indirect
-	github.com/minetest-go/mtdb v1.1.29 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.26.0 // indirect
 	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
-	github.com/sirupsen/logrus v1.9.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab // indirect
 	golang.org/x/tools v0.1.10 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/minetest-go/mapparser v0.1.8 h1:tmkno1Qi8nIdjQXJLlnq38uVGygZWA8i3ilre
 github.com/minetest-go/mapparser v0.1.8/go.mod h1:TcjEkPY9n0rBM+beSstw+Jje8nGl+LqFhiC00J6ihNw=
 github.com/minetest-go/mtdb v1.1.29 h1:515K9iFhqfqiL/3Odu/yREyMr6qjgCXLOQZIV9vzPSU=
 github.com/minetest-go/mtdb v1.1.29/go.mod h1:+xr0y7+pP65pdtB5joUSVsr22Xwvg7ZkQx9AxSj2gus=
+github.com/minetest-go/mtdb v1.1.33 h1:ypSW4WGHmmC0YSkmNJ6iDgG4I0Z7vfJf6yr+XQ7AkQ0=
+github.com/minetest-go/mtdb v1.1.33/go.mod h1:sKO3hTtIVfZSADtPEhPTd5CmQLbKLDZQiS1AvHlchyw=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=


### PR DESCRIPTION
Pinned version was forcing sqlite database for blocks,
ignoring world.mt backend info.

Fixes #158